### PR TITLE
Small fix in CLI script `rt_process_vs` to pass `sdf_path` from argument `--export_sdf_path`

### DIFF
--- a/ringtail/cli/rt_process_vs.py
+++ b/ringtail/cli/rt_process_vs.py
@@ -62,7 +62,7 @@ def main():
 
             # write out molecules if requested
             if outopts.export_sdf_path:
-                rtcore.write_molecule_sdfs()
+                rtcore.write_molecule_sdfs(sdf_path = outopts.export_sdf_path)
 
             # write out requested CSVs
             if readopts["export_bookmark_csv"]:

--- a/ringtail/ringtailcore.py
+++ b/ringtail/ringtailcore.py
@@ -1674,11 +1674,12 @@ class RingtailCore:
             bookmark_filters = (
                 self.storageman.fetch_filters_from_bookmark()
             )  # fetches the filters used to produce the bookmark
-        max_miss = bookmark_filters["max_miss"]
-        if max_miss > 0:
-            raise OptionError(
-                "Cannot use --plot with --max_miss > 0. Can plot for desired bookmark with --bookmark_name."
-            )
+        if bookmark_filters:
+            max_miss = bookmark_filters["max_miss"]
+            if max_miss > 0:
+                raise OptionError(
+                    "Cannot use --plot with --max_miss > 0. Can plot for desired bookmark with --bookmark_name."
+                )
 
         logger.info("Creating plot of results")
         # get data from storageMan

--- a/ringtail/storagemanager.py
+++ b/ringtail/storagemanager.py
@@ -1623,7 +1623,9 @@ class StorageManagerSQLite(StorageManager):
         sql_query = (
             f"SELECT filters FROM Bookmarks where Bookmark_name = '{bookmark_name}'"
         )
-        filters = self._run_query(sql_query).fetchone()[0]
+        filters = self._run_query(sql_query).fetchone()
+        if not filters: 
+            return {}
 
         return json.loads(filters)
 

--- a/ringtail/storagemanager.py
+++ b/ringtail/storagemanager.py
@@ -1627,7 +1627,7 @@ class StorageManagerSQLite(StorageManager):
         if not filters: 
             return {}
 
-        return json.loads(filters)
+        return json.loads(filters[0])
 
     def bookmark_has_rows(self, bookmark_name: str) -> bool:
         """


### PR DESCRIPTION
This is a very small fix in the cli script `rt_process_vs`, to pass `sdf_path` from command line input to the rtcore writer function. 

For this argument the current help message of `rt_process_vs` is: 

>   -sdf DIRECTORY_NAME, --export_sdf_path DIRECTORY_NAME
>                         specify the path where to save poses of ligands passing the filters (SDF
>                         format); if the directory does not exist, it will be created; if it
>                         already exist, it will throw an error, unless the --overwrite is used
>                         NOTE: the log file will be automatically saved in this path. Ligands will
>                         be stored as SDF files in the order specified.

2e9e1f7 + f262f38 added a way to handle situations when no prior filters (bookmarks) exist